### PR TITLE
Potential fix for code scanning alert no. 3: Missing rate limiting

### DIFF
--- a/package.json
+++ b/package.json
@@ -81,7 +81,8 @@
     "wouter": "^3.3.5",
     "ws": "^8.18.0",
     "zod": "^3.23.8",
-    "zod-validation-error": "^3.4.0"
+    "zod-validation-error": "^3.4.0",
+    "express-rate-limit": "^7.5.0"
   },
   "devDependencies": {
     "@replit/vite-plugin-runtime-error-modal": "^0.0.3",

--- a/server/vite.ts
+++ b/server/vite.ts
@@ -1,4 +1,5 @@
 import express, { type Express } from "express";
+import rateLimit from "express-rate-limit";
 import fs from "fs";
 import path, { dirname } from "path";
 import { fileURLToPath } from "url";
@@ -81,8 +82,14 @@ export function serveStatic(app: Express) {
 
   app.use(express.static(distPath));
 
+  // Configure rate limiter: maximum of 100 requests per 15 minutes
+  const staticFileRateLimiter = rateLimit({
+    windowMs: 15 * 60 * 1000, // 15 minutes
+    max: 100, // limit each IP to 100 requests per windowMs
+  });
+
   // fall through to index.html if the file doesn't exist
-  app.use("*", (_req, res) => {
+  app.use("*", staticFileRateLimiter, (_req, res) => {
     res.sendFile(path.resolve(distPath, "index.html"));
   });
 }


### PR DESCRIPTION
Potential fix for [https://github.com/canstralian/WorkflowBuilder/security/code-scanning/3](https://github.com/canstralian/WorkflowBuilder/security/code-scanning/3)

To address the issue, we will introduce rate limiting to the route handler in the `serveStatic` function. The `express-rate-limit` package is a well-known library for implementing rate limiting in Express applications. We will configure a rate limiter to allow a maximum number of requests per time window and apply it to the route handler serving the `index.html` file. This ensures that the application is protected against excessive requests to this route.

Steps to fix:
1. Install the `express-rate-limit` package if it is not already installed.
2. Import the `express-rate-limit` package in the file.
3. Configure a rate limiter with appropriate settings (e.g., 100 requests per 15 minutes).
4. Apply the rate limiter middleware to the route handler serving the `index.html` file.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
