### PR TITLE
Create defender-for-devops.yml

### DIFF
--- a/.github/workflows/defender-for-devops.yml
+++ b/.github/workflows/defender-for-devops.yml
@@ -18,6 +18,10 @@
 
 name: "Microsoft Defender For Devops"
 
+permissions:
+  contents: read
+  security-events: write
+
 on:
   push:
     branches: [ "main" ]

--- a/.github/workflows/defender-for-devops.yml
+++ b/.github/workflows/defender-for-devops.yml
@@ -1,0 +1,47 @@
+# This workflow uses actions that are not certified by GitHub.
+# They are provided by a third-party and are governed by
+# separate terms of service, privacy policy, and support
+# documentation.
+#
+# Microsoft Security DevOps (MSDO) is a command line application which integrates static analysis tools into the development cycle.
+# MSDO installs, configures and runs the latest versions of static analysis tools
+# (including, but not limited to, SDL/security and compliance tools).
+#
+# The Microsoft Security DevOps action is currently in beta and runs on the windows-latest queue,
+# as well as Windows self hosted agents. ubuntu-latest support coming soon.
+#
+# For more information about the action , check out https://github.com/microsoft/security-devops-action
+#
+# Please note this workflow do not integrate your GitHub Org with Microsoft Defender For DevOps. You have to create an integration
+# and provide permission before this can report data back to azure.
+# Read the official documentation here : https://learn.microsoft.com/en-us/azure/defender-for-cloud/quickstart-onboard-github
+
+name: "Microsoft Defender For Devops"
+
+on:
+  push:
+    branches: [ "main" ]
+  pull_request:
+    branches: [ "main" ]
+  schedule:
+    - cron: '40 0 * * 6'
+
+jobs:
+  MSDO:
+    # currently only windows latest is supported
+    runs-on: windows-latest
+
+    steps:
+    - uses: actions/checkout@v4
+    - uses: actions/setup-dotnet@v4
+      with:
+        dotnet-version: |
+          5.0.x
+          6.0.x
+    - name: Run Microsoft Security DevOps
+      uses: microsoft/security-devops-action@v1.6.0
+      id: msdo
+    - name: Upload results to Security tab
+      uses: github/codeql-action/upload-sarif@v3
+      with:
+        sarif_file: ${{ steps.msdo.outputs.sarifFile }}

--- a/.github/workflows/defender-for-devops.yml
+++ b/.github/workflows/defender-for-devops.yml
@@ -12,7 +12,7 @@
 #
 # For more information about the action , check out https://github.com/microsoft/security-devops-action
 #
-# Please note this workflow do not integrate your GitHub Org with Microsoft Defender For DevOps. You have to create an integration
+# Please note this workflow does not integrate your GitHub Org with Microsoft Defender for DevOps. You have to create an integration.
 # and provide permission before this can report data back to azure.
 # Read the official documentation here : https://learn.microsoft.com/en-us/azure/defender-for-cloud/quickstart-onboard-github
 


### PR DESCRIPTION
This pull request introduces a new GitHub Actions workflow for integrating Microsoft Defender for DevOps into the development process. The workflow is designed to run static analysis tools via the Microsoft Security DevOps (MSDO) action and upload the results to the Security tab in GitHub.

### New GitHub Actions Workflow:

* [`.github/workflows/defender-for-devops.yml`](diffhunk://#diff-71b69d767f4e5c498496c11436abd5218311582fbf6470905dca7b40cddad17bR1-R47): Added a new workflow that uses the Microsoft Security DevOps action to perform static analysis on the `main` branch during pushes, pull requests, and a weekly scheduled run. The workflow runs on `windows-latest` and includes steps to set up .NET, execute MSDO, and upload SARIF results to the Security tab.

## Summary by Sourcery

CI:
- Add defender-for-devops.yml workflow to execute the Microsoft Security DevOps action on windows-latest, set up .NET 5 and 6, and upload analysis results to GitHub’s Security tab

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Introduced a new automated workflow to perform static analysis and security compliance checks on code changes, with results uploaded to the GitHub Security tab.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->